### PR TITLE
🐛 [-bug] CI scripts no longer using relative references

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -22,4 +22,4 @@ on:
 jobs:
   _3708d875-b4c1-4265-89d0-93553e16c0c3:
     name: "Build and Test"
-    uses: ./.github/workflows/exercise_main.yaml
+    uses: davidbrownell/v4-DavidBrownell_Backup/.github/workflows/exercise_main.yaml@CI-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,7 +26,7 @@ jobs:
   _a3fa3751-1863-4670-a89c-3e60a602ac0f:
     name: "DavidBrownell_Backup"
 
-    uses: ./.github/workflows/exercise_main.yaml
+    uses: davidbrownell/v4-DavidBrownell_Backup/.github/workflows/exercise_main.yaml@CI-latest
     with:
       repo_name: "davidbrownell/v4-DavidBrownell_Backup"
       repo_branch: "${{ github.ref_name }}"

--- a/.github/workflows/on_pr_to_main.yaml
+++ b/.github/workflows/on_pr_to_main.yaml
@@ -24,4 +24,4 @@ on:
 jobs:
   _1fbc5ab1-736c-468f-b711-b825c52d87c8:
     name: "branch: ${{ github.base_ref }}"
-    uses: ./.github/workflows/exercise_main.yaml
+    uses: davidbrownell/v4-DavidBrownell_Backup/.github/workflows/exercise_main.yaml@CI-latest

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -24,4 +24,4 @@ on:
 jobs:
   _d13b0c0e-6a87-4583-8fec-a2e1a1dd1eb6:
     name: "Build and Test"
-    uses: ./.github/workflows/exercise_main.yaml
+    uses: davidbrownell/v4-DavidBrownell_Backup/.github/workflows/exercise_main.yaml@CI-latest


### PR DESCRIPTION
Relative references weren't working when the script was invoked from a build associated with a different repo.